### PR TITLE
Add licensing info to readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,8 @@ main = defaultMain $ do
         putStrLn $ "using flag A : " ++ show (toParam flagA)
         putStrLn $ "args: " ++ show (toParam allArgs)
 ```
+
+License
+-------
+
+The source code of cli is available under the [BSD 3-Clause license](https://opensource.org/licenses/BSD-3-Clause), see `LICENSE` for more information.


### PR DESCRIPTION
Add information on the licensing of the library to the readme file in order to make it easier to find.
