### PR TITLE
export type ValueParser

### DIFF
--- a/Console/Options.hs
+++ b/Console/Options.hs
@@ -66,6 +66,7 @@ module Console.Options
     , description
     , Action
     -- * Arguments
+    , ValueParser
     , FlagParser(..)
     , Flag
     , FlagLevel


### PR DESCRIPTION
This will allow ValueParser to be documented as well.

Fixing issue #4 
